### PR TITLE
fix(pages): shuffle first row

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -74,7 +74,7 @@
     (() => {
       function sortTable(tbody) {
         let rowsCollection = tbody.querySelectorAll("tr");
-        let rows = Array.from(rowsCollection).slice(1);
+        let rows = Array.from(rowsCollection);
         shuffleArray(rows);
         for (const row of rows) {
           tbody.appendChild(row);


### PR DESCRIPTION
original shuffle code excluded the `thead` row. This code was updated in this [PR](https://github.com/eth-clients/checkpoint-sync-endpoints/pull/7) but did not remove the excluded first row.

This change fixes that by shuffling all rows in the `tbody`