### PR TITLE
revert: fix: main to master rename

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'eth-clients/checkpoint-sync-endpoints'
-          ref: master
+          ref: main
           path: remote
       - name: Combine endpoints
         run: |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project is an extension of [https://github.com/eth-clients/checkpoint-sync-endpoints](https://github.com/eth-clients/checkpoint-sync-endpoints) that adds a health check column to the endpoint tables.
 
 On [schedule](./.github/workflows/check.yaml#L5) a Github action is triggered that;
-- pulls down the remote [`endpoints/*.yaml`](https://github.com/eth-clients/checkpoint-sync-endpoints/blob/master/endpoints/)
+- pulls down the remote [`endpoints/*.yaml`](https://github.com/eth-clients/checkpoint-sync-endpoints/blob/main/endpoints/)
 - runs a health check on each endpoint
 - updates the `health` field on every endpoint
 - commits new `health` changes of [`./_data/endpoints.yaml`](./_data/endpoints.yaml)
@@ -22,7 +22,7 @@ On [schedule](./.github/workflows/check.yaml#L5) a Github action is triggered th
 # copy current stored endpoints
 cp _data/endpoints.yaml endpoints.yaml
 
-# OR combine the endpoints from https://github.com/eth-clients/checkpoint-sync-endpoints/tree/master/endpoints
+# OR combine the endpoints from https://github.com/eth-clients/checkpoint-sync-endpoints/tree/main/endpoints
 ```
 
 ### Update `_data/endpoints.yaml`


### PR DESCRIPTION
remote `eth-clients/checkpoint-sync-endpoints` is still `main`

revert of https://github.com/ethpandaops/checkpoint-sync-health-checks/pull/5